### PR TITLE
Allow Senzing license to be provided to streamloader helm chart

### DIFF
--- a/charts/senzing-stream-loader/templates/deployment.yaml
+++ b/charts/senzing-stream-loader/templates/deployment.yaml
@@ -300,8 +300,13 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-          {{- if .Values.senzing.persistentVolumeClaim }}
           volumeMounts:
+            {{- if .Values.senzing.license }}
+            - name: senzing-license
+              mountPath: /opt/senzing/license
+              readOnly: true
+            {{- end }}
+            {{- if .Values.senzing.persistentVolumeClaim }}
             - name: senzing-storage
               mountPath: /opt/senzing/data
               subPath: senzing-data/2.0.0
@@ -317,16 +322,30 @@ spec:
             - name: senzing-storage
               mountPath: /opt/IBM
               subPath: senzing-db2-drivers
+            {{- end }}
+          {{- if .Values.senzing.license }}
+          lifecycle:
+            postStart:
+              exec:
+                command:
+                  - /bin/sh
+                  - -c
+                  - rm -r {{ .Values.senzing.licensePath }}; cp /opt/senzing/license/g2.lic {{ .Values.senzing.licensePath }}
           {{- end }}
       {{- if .Values.rbacEnabled}}
       serviceAccountName: {{ template "senzing-stream-loader.fullname" . }}
       {{- end }}
-      {{- if .Values.senzing.persistentVolumeClaim }}
       volumes:
+        {{- if .Values.senzing.license }}
+        - name: senzing-license
+          secret:
+            secretName: senzing-license
+        {{- end }}
+        {{- if .Values.senzing.persistentVolumeClaim }}
         - name: senzing-storage
           persistentVolumeClaim:
             claimName: {{ .Values.senzing.persistentVolumeClaim }}
-      {{- end }}
+        {{- end }}
 # --- Standard suffix ---
       {{- with .Values.affinity }}
       affinity:

--- a/charts/senzing-stream-loader/templates/secret.yaml
+++ b/charts/senzing-stream-loader/templates/secret.yaml
@@ -1,0 +1,10 @@
+{{- if .Values.senzing.license }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: senzing-license
+type: Opaque
+data:
+  g2.lic: {{ .Values.senzing.license }}
+{{- end }}
+

--- a/charts/senzing-stream-loader/values.yaml
+++ b/charts/senzing-stream-loader/values.yaml
@@ -40,6 +40,7 @@ securityContext:
 senzing:
   persistentVolumeClaim: senzing-persistent-volume-claim
   subcommand: kafka
+  licensePath: /etc/opt/senzing/g2.lic
 
 service:
   port: 80


### PR DESCRIPTION
# Pull request questions

## Why was change needed

The current helm chart for streamloader does not provide any way to inject a license file in the helm chart. the only option is to add it to the base image.

## What does change improve

This change allows the license to be added to a senzing.license key in the helm chart values. This license will be stored in a kubernetes secret and placed at runtime into the file specified in the senzing.licensePath key (defaulted to /etc/opt/senzing/g2.lic). If no license entry is specified in the helm chart values then the original behaviour will be expected.

Notes:
1. This change stores the license in a secret called senzing-license. This could be improved in the future by creating this secret in a new helm chart which could then be referenced as a dependency in all the other helm charts (including stream-loader) that require a license.
2. Because of Kubernetes' inability to map a file, and the requirement for the g2.lic file to be stored in the same directory as other files, this implementation adds the secret to a generic path and then copies this to the location specified in licensePath. This has the dependency that the pod default UID must have the permission to create files in the directory specified by licensePath.
